### PR TITLE
Enable nats to run using nonroot user

### DIFF
--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -20,6 +20,9 @@ COPY nats-server /bin/nats-server
 COPY --from=builder /nats /bin/nats
 COPY --from=builder /go/bin/nsc /bin/nsc
 
+RUN apk add --no-cache libcap \
+  && setcap cap_net_bind_service=+ep /bin/nats-server
+
 EXPOSE 4222 8222 6222 5222
 
 ENTRYPOINT ["/bin/nats-server"]


### PR DESCRIPTION
I am trying to run nats in k8s as nonroot user. nats-server is listening to port 443 for wss protocol. This change allows nats-server to bind to port 443 .

The reason this is required is because k8s does not support ambient capabilities yet.
- https://github.com/kubernetes/enhancements/issues/2763
- https://github.com/kubernetes/kubernetes/issues/56374

ingress-nginx project also uses this in their Dockerfile to allow nonroot user
https://github.com/kubernetes/ingress-nginx/blob/48fbdfe3ba0c0e258890c970e2561caecea532dd/rootfs/Dockerfile#L70

Signed-off-by: Tamal Saha <tamal@appscode.com>
